### PR TITLE
Fix TOML highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ evaluate user-provided expressions in a larger context.
 
 Add the crate to your `Cargo.toml`:
 
-```
+```toml
 [dependencies]
 caldyn = "0.3"
 ```


### PR DESCRIPTION
Before: 
![before SS](https://user-images.githubusercontent.com/6709544/29996532-b78a27d6-9000-11e7-84d2-53ba0f87f5e7.png)

After: 
![after SS](https://user-images.githubusercontent.com/6709544/29996535-d0e94b62-9000-11e7-9ecb-e6595cb43b62.png)
